### PR TITLE
fix: updates arg type for fetch method

### DIFF
--- a/src/slims/slims.py
+++ b/src/slims/slims.py
@@ -112,7 +112,7 @@ class Slims(object):
     def token_updater(self, token: dict[str, Any]) -> None:
         self.token = token
 
-    def fetch(self, table: str, criteria: Criterion, sort: list[str] = None,
+    def fetch(self, table: str, criteria: Optional[Criterion], sort: list[str] = None,
               start: int = None, end: int = None) -> List[Record]:
         """Fetch data by criteria
 
@@ -121,7 +121,7 @@ class Slims(object):
 
         Args:
             table (str): The table to fetch from
-            criteria (criteria): The criteria to match
+            criteria (criteria or None): The criteria to match
             sort (list, optional): The fields to sort on
             start (int, optional):  The first row to return
             end (int, optional): The last row to return


### PR DESCRIPTION
In some of the examples and in the body of the fetch method, it's apparent that the criteria argument can be `None`. I updated the argument type so that IDE warnings don't appear when setting `criteria=None` when using the fetch method.